### PR TITLE
feat: support tx-archive std format

### DIFF
--- a/extractor/main.go
+++ b/extractor/main.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
 	"github.com/gnolang/gno/tm2/pkg/amino"
-	"github.com/gnolang/gno/tm2/pkg/std"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"golang.org/x/sync/errgroup"
 	"io"
@@ -104,16 +103,6 @@ func execExtract(ctx context.Context, cfg *extractorCfg) error {
 	if cfg.outputDir == "" {
 		return errInvalidOutputDir
 	}
-
-	//// Find the files that need to be analyzed
-	//sourceFiles, findErr := findFilePaths(cfg.sourcePath, cfg.fileType)
-	//if findErr != nil {
-	//	return fmt.Errorf("unable to find file paths, %w", findErr)
-	//}
-	//
-	//if len(sourceFiles) == 0 {
-	//	return errNoSourceFilesFound
-	//}
 
 	// Check if source is valid
 	source, err := os.Stat(cfg.sourcePath)
@@ -236,7 +225,7 @@ func extractAddMessages(filePath string) ([]vm.MsgAddPackage, error) {
 	tempBuf := make([]byte, 0)
 
 	for {
-		var tx std.Tx
+		var tx TxData
 		line, isPrefix, err := reader.ReadLine()
 
 		// Exit if no more lines in file
@@ -272,7 +261,7 @@ func extractAddMessages(filePath string) ([]vm.MsgAddPackage, error) {
 			tempBuf = nil
 		}
 
-		for _, msg := range tx.Msgs {
+		for _, msg := range tx.Tx.Msgs {
 			// Only MsgAddPkg should be parsed
 			if msg.Type() != "add_package" {
 				continue

--- a/extractor/main.go
+++ b/extractor/main.go
@@ -104,24 +104,10 @@ func execExtract(ctx context.Context, cfg *extractorCfg) error {
 		return errInvalidOutputDir
 	}
 
-	// Check if source is valid
-	source, err := os.Stat(cfg.sourcePath)
-	if err != nil {
-		return fmt.Errorf("unable to open source, %w", err)
-	}
-
-	var sourceFiles []string
-	var findErr error
-
-	// If source is dir, walk it and add to sourceFiles
-	if source.IsDir() {
-		sourceFiles, findErr = findFilePaths(cfg.sourcePath, cfg.fileType)
-		if findErr != nil {
-			return fmt.Errorf("unable to find file paths, %w", findErr)
-		}
-	} else {
-		// If source is not dir, open the file directly
-		sourceFiles = append(sourceFiles, cfg.sourcePath)
+	// Find the files that need to be analyzed
+	sourceFiles, findErr := findFilePaths(cfg.sourcePath, cfg.fileType)
+	if findErr != nil {
+		return fmt.Errorf("unable to find file paths, %w", findErr)
 	}
 
 	if len(sourceFiles) == 0 {
@@ -132,6 +118,7 @@ func execExtract(ctx context.Context, cfg *extractorCfg) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	for _, sourceFile := range sourceFiles {
+		// Redeclare locally for thread safety
 		sourceFile := sourceFile
 
 		g.Go(func() error {

--- a/extractor/main_test.go
+++ b/extractor/main_test.go
@@ -41,36 +41,36 @@ func TestExtractor_Errors(t *testing.T) {
 		{
 			"no source files",
 			&extractorCfg{
-				fileType:  ".log",
-				sourceDir: "./",
-				outputDir: ".",
+				fileType:   ".log",
+				sourcePath: "./",
+				outputDir:  ".",
 			},
 			errNoSourceFilesFound,
 		},
 		{
 			"invalid filetype",
 			&extractorCfg{
-				fileType:  "",
-				sourceDir: ".",
-				outputDir: ".",
+				fileType:   "",
+				sourcePath: ".",
+				outputDir:  ".",
 			},
 			errInvalidFileType,
 		},
 		{
 			"invalid source dir",
 			&extractorCfg{
-				fileType:  ".log",
-				sourceDir: "",
-				outputDir: ".",
+				fileType:   ".log",
+				sourcePath: "",
+				outputDir:  ".",
 			},
 			errInvalidSourceDir,
 		},
 		{
 			"invalid output dir",
 			&extractorCfg{
-				fileType:  ".log",
-				sourceDir: ".",
-				outputDir: "",
+				fileType:   ".log",
+				sourcePath: ".",
+				outputDir:  "",
 			},
 			errInvalidOutputDir,
 		},
@@ -106,9 +106,9 @@ func TestValidFlow(t *testing.T) {
 
 	// Set correct config
 	var cfg = &extractorCfg{
-		fileType:  sourceFileType,
-		sourceDir: sourceDir,
-		outputDir: outputDir,
+		fileType:   sourceFileType,
+		sourcePath: sourceDir,
+		outputDir:  outputDir,
 	}
 
 	// Generate mock messages & mock files

--- a/extractor/main_test.go
+++ b/extractor/main_test.go
@@ -310,14 +310,16 @@ func generateSourceFiles(t *testing.T, dir string, mockMsgs []std.Msg) []string 
 	t.Helper()
 
 	var (
-		mockTx    = make([]std.Tx, numTx)
+		mockTx    = make([]TxData, numTx)
 		testFiles = make([]string, numSourceFiles)
 	)
 
 	// Generate transactions to wrap messages
 	for i := range mockTx {
-		mockTx[i] = std.Tx{
-			Msgs: mockMsgs[:msgPerTx],
+		mockTx[i] = TxData{
+			Tx: std.Tx{
+				Msgs: mockMsgs[:msgPerTx],
+			},
 		}
 		mockMsgs = mockMsgs[msgPerTx:]
 	}
@@ -464,7 +466,7 @@ func randString(t *testing.T, length int) string {
 	return base64.StdEncoding.EncodeToString(buf)
 }
 
-func writeTxToFile(t *testing.T, tx std.Tx, file *os.File) error {
+func writeTxToFile(t *testing.T, tx TxData, file *os.File) error {
 	t.Helper()
 
 	data, err := amino.MarshalJSON(tx)

--- a/extractor/types.go
+++ b/extractor/types.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/gnolang/gno/gno.land/pkg/sdk/vm"
+	"github.com/gnolang/gno/tm2/pkg/std"
 )
 
 // Metadata defines the metadata info that accompanies
@@ -9,6 +10,13 @@ import (
 type Metadata struct {
 	Creator string `json:"creator"` // the creator of the source code (deployer)
 	Deposit string `json:"deposit"` // the deposit associated with the deployment
+}
+
+// TxData contains the single block transaction,
+// along with the block information
+type TxData struct {
+	Tx       std.Tx `json:"tx"`
+	BlockNum uint64 `json:"blockNum"`
 }
 
 // metadataFromMsg extracts the metadata from a message


### PR DESCRIPTION
## Description

This PR changes the exporter internals to handle the new, [standard format](https://github.com/gnolang/tx-archive/blob/254ce6d9ced21782edb0e54d407965e06074afe3/types/types.go#L7) of transaction data, instead of the legacy one from [tx-archive](https://github.com/gnolang/tx-archive). 